### PR TITLE
add basic mask support

### DIFF
--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -17,3 +17,4 @@ struct Mask{T<:AbstractArray} <: SemanticWrapper
 end
 
 unwrap(m::Mask) = m.img
+plain_array(m::Mask) = Mask(plain_array(unwrap(m)))

--- a/test/tst_operations.jl
+++ b/test/tst_operations.jl
@@ -23,10 +23,10 @@
         notapplicable = []
         for op in ops
             for what in applicable
-                @test Augmentor.shouldapply(op, what)
+                @test Augmentor.shouldapply(op, what) == Val(true)
             end
             for what in notapplicable
-                @test !Augmentor.shouldapply(op, what)
+                @test Augmentor.shouldapply(op, what) == Val(false)
             end
         end
     end
@@ -37,10 +37,10 @@
         notapplicable = [Augmentor.Mask]
         for op in ops
             for what in applicable
-                @test Augmentor.shouldapply(op, what)
+                @test Augmentor.shouldapply(op, what) == Val(true)
             end
             for what in notapplicable
-                @test !Augmentor.shouldapply(op, what)
+                @test Augmentor.shouldapply(op, what) == Val(false)
             end
         end
     end


### PR DESCRIPTION
Operations like this isn't inferrable because we can't guarantee that `typeof(img) == typeof(output)`:

```julia
shouldapply(op, img) ? ($FUN)(op, img, randparam(op, img)) : img
```

For this reason, I use `Val(true)` here to support multiple dispatch so as to be able to infer the result. (You can see `Val(true)` as a simple version of trait types)

---

Is this expected?

```julia
julia> Augmentor.shouldapply(ColorJitter(1.2, [0.5, 0.8]), Mask(img))
Val{true}()
```